### PR TITLE
Modify header of output vcf

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To rescue variants filtered out, or of low quality, against positions to never e
 **Optional**:
 
 - `strip_chr` (`bool`): if true, will strip chr prefixes from input vcfs. Should be specified if given reference fasta does not contain chr prefixes.
-- `filter_tag` (`string`): tag to add to `FILTER` field of rescued variants (default: `rescued`)
+- `filter_tag` (`string`): tag to add to `FILTER` field of rescued variants (default: `rescued`), this will be appended to any existing FILTER fields (`bcftools filter -m +`).
 
 
 ## What does this app output?

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To rescue variants filtered out, or of low quality, against positions to never e
 
 - `strip_chr` (`bool`): if true, will strip chr prefixes from input vcfs. Should be specified if given reference fasta does not contain chr prefixes.
 - `filter_tag` (`string`): tag to add to `FILTER` field of rescued variants (default: `rescued`), this will be appended to any existing FILTER fields (`bcftools filter -m +`).
+- `filter_tag_description` (`string`): additional description to append to FILTER line in header for provenance of rescued variants. Default description: `##FILTER=<ID={$filter_tag},Description="Record masked by region; variants added in eggd_vcf_rescue (DNAnexus job: $DX_JOB_ID)">`
 
 
 ## What does this app output?

--- a/dxapp.json
+++ b/dxapp.json
@@ -99,6 +99,14 @@
       "default": "rescued",
       "group": "optional",
       "help": "tag to apply to FILTER field of rescued variants"
+    },
+    {
+      "name": "filter_tag_description",
+      "label": "filter tag description",
+      "class": "string",
+      "optional": true,
+      "group": "optional",
+      "help": "extra description to append to FILTER field in vcf header for given filter_tag"
     }
   ],
   "outputSpec": [

--- a/src/eggd_vcf_rescue.sh
+++ b/src/eggd_vcf_rescue.sh
@@ -87,7 +87,7 @@ _compress_and_index() {
 _modify_header() {
     : '''
     Modifies vcf header after calling bcftools filter to update FILTER description
-    added for the given filter_tag to link to current DNAnexusjob
+    added for the given filter_tag to link to current DNAnexus job
 
     Arguments:
         file : vcf file with applied filter_tag
@@ -104,7 +104,11 @@ _modify_header() {
     header_line=$(grep "^##FILTER=<ID=${filter_tag}" header.txt)
     description_addition="variants rescued against given variant positions "
     description_addition+="in eggd_vcf_rescue (DNAnexus job: $DX_JOB_ID)"
-    if [[ -z "$filter_tag_description" ]]; then description_addition+=". ${filter_tag_description}"; fi
+    if [[ "$filter_tag_description" ]]; then
+        # add additional description if given, replace double with single quotes
+        # if given to not break the header
+        description_addition+=". ${filter_tag_description/\"/\'}"
+    fi
 
     modified_header_line=${header_line/\">/; $description_addition\">}
     sed -i "s/$header_line/$modified_header_line/" header.txt
@@ -191,7 +195,7 @@ _rescue_non_pass() {
 
     # modified description for FILTER field added by bcftools filter to better explain
     # provenance of filter_tag
-    _modify_header ${sample_prefix}.rescued.vcf.gz
+    _modify_header "${sample_prefix}.rescued.vcf.gz"
 
     # Create a vcf with only PASS variants
     bcftools view -f PASS "${sample_prefix}_norm.vcf" -Oz -o "${sample_prefix}_pass.vcf.gz"

--- a/src/eggd_vcf_rescue.sh
+++ b/src/eggd_vcf_rescue.sh
@@ -183,9 +183,13 @@ _rescue_non_pass() {
     bcftools view -m2 "$gvcf_name" -o "${sample_prefix}.vcf"
 
     if [[ "$strip_chr" == 'true' ]]; then
-        # remove chr prefix from sample vcf
+        # remove chr prefix from sample vcf and rescue vcf
         _strip_chr_prefix "${sample_prefix}.vcf" "${sample_prefix}.tmp.vcf"
         mv "${sample_prefix}.tmp.vcf" "${sample_prefix}.vcf"
+
+        _strip_chr_prefix "$rescue_vcf_name" "tmp.vcf"
+        mv tmp.vcf "${rescue_vcf_name/.gz/}"
+        rescue_vcf_name="${rescue_vcf_name/.gz/}"  # overwrite global variable to new file
     fi
 
     # Normalise and left align filtered vcf


### PR DESCRIPTION
## Summary

Adds function `_modify_header` to add to the description in the FILTER field of the output vcf added by `bcftools filter`, this adds more detail on the provenance of the filter, the DNAnexus job for the vcf and (optionally) a user specified description. Additionally, will clean up invalid characters from `filter_tag` and `filter_tag_description`.

## Test jobs
- default: https://platform.dnanexus.com/projects/GFxv0P84v9B433JX4vzqv1VZ/monitor/job/GFz066Q4v9B2PbF34bvj0QY0
```
$ dx cat file-GFz07X04Q0v7jpQV4x5FXZj5 | zgrep "^##FILTER" | tail -n1
##FILTER=<ID=rescued,Description="Record masked by region; variants rescued against given variant positions in eggd_vcf_rescue (DNAnexus job: job-GFz066Q4v9B2PbF34bvj0QY0)">
```

- with and `filter_tag` and `filter_tag_description`: https://platform.dnanexus.com/projects/GFxv0P84v9B433JX4vzqv1VZ/monitor/job/GFz07z04v9B0kPP99zb45720
```
$ dx cat file-GFz09184YYXX1kB24qf47g0q | zgrep "^##FILTER" | tail -n1
##FILTER=<ID=some_ID_with_invalid_characters_and_mixed_quotes,Description="Record masked by region; variants rescued against given variant positions in eggd_vcf_rescue (DNAnexus job: job-GFz07z04v9B0kPP99zb45720). Some additional detail about the tag with 'double quotes'.">
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vcf_rescue/5)
<!-- Reviewable:end -->
