### PR TITLE
URA 595 filter variants with csq annotation

### DIFF
--- a/src/eggd_vcf_rescue.sh
+++ b/src/eggd_vcf_rescue.sh
@@ -183,11 +183,10 @@ _filter_variants() {
     num_var=$(zcat "${filtered_vcf_name}.gz" | grep -v ^"#" | wc -l)
     echo "VCF has $num_var variants before filtering variants"
 
-    # split vep annotation if CSQ annotation is detected
-    zgrep "CSQ=" "${filtered_vcf_name}.gz" > vcf_vep
-    if [ -z "${vcf_vep}" ]; then
-        echo "VCF is annotated"
-        # so VCF filtering on CSQ can be done. Filtering requires the VCF to be split
+    # split vep annotation if CSQ in filter_string is detected
+    if [[ "$filter_string" == *CSQ* ]]; then
+        echo "filter string contains CSQ filtering"
+        # VCF filtering on CSQ can be done but requires the VCF to be split
         # -c Extract the fields listed either as 0-based indexes or names
         # -a INFO annotation to parse [CSQ]
         bcftools +split-vep --columns - -a CSQ -Ou -p 'CSQ_'  "${filtered_vcf_name}.gz" |  bcftools annotate -x INFO/CSQ -o split_vcf.vcf
@@ -199,7 +198,7 @@ _filter_variants() {
         mv isec/0003.vcf "${filtered_vcf_name}"
 
     else
-        echo "VCF is not annotated therefore expects no CSQ specific filtering"
+        echo "CSQ specific filtering NOT requested"
         eval ${filter_string} "${filtered_vcf_name}.gz" -o "$filtered_vcf_name"
     fi
 

--- a/src/eggd_vcf_rescue.sh
+++ b/src/eggd_vcf_rescue.sh
@@ -189,7 +189,7 @@ _filter_variants() {
         # VCF filtering on CSQ can be done but requires the VCF to be split
         # -c Extract the fields listed either as 0-based indexes or names
         # -a INFO annotation to parse [CSQ]
-        #-p prepend string 'CSQ_' to all CSQ fields to avoid tag name conflicts
+        # -p prepend string 'CSQ_' to all CSQ fields to avoid tag name conflicts
         bcftools +split-vep --columns - -a CSQ -Ou -p 'CSQ_'  "${filtered_vcf_name}.gz" |  bcftools annotate -x INFO/CSQ -o split_vcf.vcf
         eval ${filter_string} split_vcf.vcf -o filtered_split_vcf.vcf
         # this VCF still has the split vcf annotation style so will need

--- a/src/eggd_vcf_rescue.sh
+++ b/src/eggd_vcf_rescue.sh
@@ -189,6 +189,7 @@ _filter_variants() {
         # VCF filtering on CSQ can be done but requires the VCF to be split
         # -c Extract the fields listed either as 0-based indexes or names
         # -a INFO annotation to parse [CSQ]
+        #-p prepend string 'CSQ_' to all CSQ fields to avoid tag name conflicts
         bcftools +split-vep --columns - -a CSQ -Ou -p 'CSQ_'  "${filtered_vcf_name}.gz" |  bcftools annotate -x INFO/CSQ -o split_vcf.vcf
         eval ${filter_string} split_vcf.vcf -o filtered_split_vcf.vcf
         # this VCF still has the split vcf annotation style so will need

--- a/src/eggd_vcf_rescue.sh
+++ b/src/eggd_vcf_rescue.sh
@@ -192,10 +192,10 @@ _filter_variants() {
         # -a INFO annotation to parse [CSQ]
         bcftools +split-vep --columns - -a CSQ -Ou -p 'CSQ_'  "${filtered_vcf_name}.gz" |  bcftools annotate -x INFO/CSQ -o split_vcf.vcf
         eval ${filter_string} split_vcf.vcf -o "$filtered_vcf_name"
-
-    else;
-        echo "VCF is not annotated"
+    then
+        echo "VCF is not annotated therefore expects no CSQ specific filtering"
         eval ${filter_string} "${filtered_vcf_name}.gz" -o "$filtered_vcf_name"
+    fi
 
     # check number of enteries after variant quality filtering
     num_var=$(grep -v ^"#"  "${filtered_vcf_name}" | wc -l)


### PR DESCRIPTION
An annotated VCF can be passed through and filtered, if user puts in a filtering string for any of consequences no filtering will be applied. 

Example job: https://platform.dnanexus.com/panx/projects/GgBvqP0421zvgj2P11Xqyg36/monitor/job/Ggy4758421zVBjfGx7p1p939

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vcf_rescue/8)
<!-- Reviewable:end -->
